### PR TITLE
Service Workers updated and vite.config.ts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
 ## Background (Required)
 
-/\*_ Put a description of the Pull Request and Why You Opened It _/
+/\*_ Updated vite.config.ts, and added claims-sw.ts and prompt-sw.ts _/
 
 ## Changes (Required)
 
-/\*_ Include a description of the changes that were made at a high level and what they are intended to solve _/
+/\*_ The vite.config.ts file did not have the complete manifest from the React example. The claims-sw.ts and prompt-sw.ts needed to be added under src/. This was acuired from the examples/react-router package directory. There was an issue with the event, eventlistener, and the ServiceWorkerGlobalScope. /// <reference lib="webworker" /> needed to be added to both service worker files._/
 
 ## Rollback (Required)
 
-/** In case we encounted an issue with this PR in the future and we need to revert back.... \*/
-/** What do you we need to know before doing that so we don't make things worse \*/
+/** In case issues arise with this branch rollback to previous version. \*/
+/** The previous version did not have the files listed above, and it had an incomplete manifest.webmanifest. This will have to be competed to move forward with project completion. \*/
 
 ## TODO (Optional)
 
-[ ] TODO List of things that still need to be accomplished before review, merging, etc
+[ ] TODO: Nothing to do before review and merging. All of Task 2 complete.
 
 ### Notes (Optional)
 
-/\*_ Helpful notes for the future _/
+/\*_ Consult Stack Overflow before spending 2 hours trying to find out why the service worker isn't working correctly_/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "notes-desktop-pwa",
       "version": "0.0.0",
       "dependencies": {
+        "@rollup/plugin-replace": "^5.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -21,7 +22,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5",
+        "vite": "^4.5.0",
         "vite-plugin-pwa": "^0.16.6"
       }
     },
@@ -2261,8 +2262,7 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
@@ -2308,6 +2308,68 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+      "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -4906,7 +4968,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5185,7 +5246,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@rollup/plugin-replace": "^5.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -13,7 +14,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5",
+    "vite": "^4.5.0",
     "vite-plugin-pwa": "^0.16.6"
   },
   "name": "notes-desktop-pwa",

--- a/src/claims-sw.ts
+++ b/src/claims-sw.ts
@@ -1,0 +1,27 @@
+/// <reference lib="webworker" />
+import {
+  cleanupOutdatedCaches,
+  createHandlerBoundToURL,
+  precacheAndRoute,
+} from "workbox-precaching";
+import { clientsClaim } from "workbox-core";
+import { NavigationRoute, registerRoute } from "workbox-routing";
+
+declare let self: ServiceWorkerGlobalScope;
+
+// self.__WB_MANIFEST is default injection point
+precacheAndRoute(self.__WB_MANIFEST);
+
+// clean old assets
+cleanupOutdatedCaches();
+
+let allowlist: undefined | RegExp[];
+if (import.meta.env.DEV) allowlist = [/^\/$/];
+
+// to allow work offline
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL("index.html"), { allowlist })
+);
+
+self.skipWaiting();
+clientsClaim();

--- a/src/prompt-sw.ts
+++ b/src/prompt-sw.ts
@@ -1,0 +1,22 @@
+/// <reference lib="webworker" />
+import {
+  cleanupOutdatedCaches,
+  createHandlerBoundToURL,
+  precacheAndRoute,
+} from "workbox-precaching";
+import { NavigationRoute, registerRoute } from "workbox-routing";
+
+declare let self: ServiceWorkerGlobalScope;
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") self.skipWaiting();
+});
+
+// self.__WB_MANIFEST is default injection point
+precacheAndRoute(self.__WB_MANIFEST);
+
+// clean old assets
+cleanupOutdatedCaches();
+
+// to allow work offline
+registerRoute(new NavigationRoute(createHandlerBoundToURL("index.html")));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
   build: {
     sourcemap: process.env.SOURCE_MAP === "true",
     outDir: "build",
+    manifest: true,
   },
   server: {
     port: 3000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,58 @@
+import process from "node:process";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import type { ManifestOptions, VitePWAOptions } from "vite-plugin-pwa";
 import { VitePWA } from "vite-plugin-pwa";
+import replace from "@rollup/plugin-replace";
 
-// https://vitejs.dev/config/
+const pwaOptions: Partial<VitePWAOptions> = {
+  mode: "development",
+  base: "/",
+  includeAssets: ["favicon.svg"],
+  manifest: {
+    name: "notes pwa",
+    short_name: "npwa",
+    theme_color: "#ffffff",
+  },
+  devOptions: {
+    enabled: process.env.SW_DEV === "true",
+    /* when using generateSW the PWA plugin will switch to classic */
+    type: "module",
+    navigateFallback: "index.html",
+  },
+};
+
+const replaceOptions = { __DATE__: new Date().toISOString() };
+const claims = process.env.CLAIMS === "true";
+const reload = process.env.RELOAD_SW === "true";
+const selfDestroying = process.env.SW_DESTROY === "true";
+
+if (process.env.SW === "true") {
+  pwaOptions.srcDir = "src";
+  pwaOptions.filename = claims ? "claims-sw.ts" : "prompt-sw.ts";
+  pwaOptions.strategies = "injectManifest";
+  (pwaOptions.manifest as Partial<ManifestOptions>).name =
+    "PWA Inject Manifest";
+  (pwaOptions.manifest as Partial<ManifestOptions>).short_name = "PWA Inject";
+}
+
+if (claims) pwaOptions.registerType = "autoUpdate";
+
+if (reload) {
+  // @ts-expect-error just ignore
+  replaceOptions.__RELOAD_SW__ = "true";
+}
+
+if (selfDestroying) pwaOptions.selfDestroying = selfDestroying;
+
 export default defineConfig({
-  plugins: [
-    VitePWA({
-      registerType: "autoUpdate",
-      manifest: {
-        name: "Notes PWA",
-        short_name: "NPWA",
-      },
-    }),
-    react(),
-  ],
+  // base: process.env.BASE_URL || 'https://github.com/',
   build: {
+    sourcemap: process.env.SOURCE_MAP === "true",
     outDir: "build",
   },
   server: {
     port: 3000,
   },
+  plugins: [react(), VitePWA(pwaOptions), replace(replaceOptions)],
 });


### PR DESCRIPTION
## Background
Updated vite.config.ts, and added claims-sw.ts and prompt-sw.ts

## Changes
The vite.config.ts file did not have the complete manifest from the React example. The claims-sw.ts and prompt-sw.ts needed to be added under src/. This was acuired from the examples/react-router package directory. There was an issue with the event, eventlistener, and the ServiceWorkerGlobalScope. /// <reference lib="webworker" /> needed to be added to both service worker files.

## Rollback
The previous version did not have the files listed above, and it had an incomplete manifest.webmanifest. This will have to be competed to move forward with project completion.

## TODO
[X] TODO Nothing to do before review and merging. All of Task 2 complete.

### Notes
Consult Stack Overflow before spending 2 hours trying to find out why the service worker isn't working correctly

